### PR TITLE
Russia correction: grant receivers don't need to send ADs

### DIFF
--- a/js/handling_data.js
+++ b/js/handling_data.js
@@ -775,7 +775,7 @@ var jsonData = [{
       "public_service_employees": "yes",
       "judges_prosecutors_court_directors": "yes",
       "managers_of_state_owned_enterprises": "yes",
-      "grant_receivers": "yes",
+      "grant_receivers": "no",
       "relatives_of_public_officials": "yes",
       "other": ""
       },


### PR DESCRIPTION
As requested by Jvirblis: 
> Russia/  Scope of asset disclosure – type and rank of officials/ Grant receivers -> wrong